### PR TITLE
Return no observations when table does not (yet) exist

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -18,7 +18,7 @@
 
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "0.1.8"
+    const val project = "0.2.2"
 
     const val java = 17
 


### PR DESCRIPTION
# Problem
When JDBC connector has not yet provessed any Kafka data, the table holding this data is not created yet. This causes data dashboard backend to throw an error.

# Solution
When the error is table not existing, an empty list of observations is returned.